### PR TITLE
pyrosm v0.8.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.7.0" %}
+{% set version = "0.8.0" %}
 {% set name = "pyrosm" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a2dcb46c44b1d1ca9de8e62bd8a5159f42d80f63ccf4a7ee67ae9c16a2c59b52
+  sha256: 0774b5e853be74e4e292eb0073f321ccd42658e622c317af2f31e164e4969fb7
 
 build:
   number: 0
@@ -25,22 +25,24 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=18.0
     - wheel
-    - cykhash >=2.0
-    - cython >=0.28
+    - cython
+    - cykhash >=2
+    - certifi
     - geopandas >=0.12.0
-    - pyrobuf >=0.9.3
+    - protobuf >=6.33.5
     - python-rapidjson
-    - shapely >=2.0
+    - shapely >=2.1
   run:
     - python
-    - cykhash >=2.0
-    - cython >=0.28
+    - setuptools >=18.0
+    - cykhash >=2
+    - certifi
     - geopandas >=0.12.0
-    - pyrobuf >=0.9.3
+    - protobuf >=6.33.5
     - python-rapidjson
-    - shapely >=2.0
+    - shapely >=2.1
 
 test:
   imports:


### PR DESCRIPTION
Updates the feedstock to pyrosm 0.8.0 ([PyPI release](https://pypi.org/project/pyrosm/0.8.0/)).

## Changes

- Bump `version` to `0.8.0` and update `sha256` to match the PyPI sdist (`pyrosm-0.8.0.tar.gz`).
- Build number stays at `0` (version bump).

Dependency changes, taken from the 0.8.0 sdist's `setup.py` (`install_requires`) and `pyproject.toml` (`build-system.requires`):

- Replace `pyrobuf >=0.9.3` with `protobuf >=6.33.5` (0.8.0 switched its protobuf backend).
- Bump `shapely >=2.0` → `>=2.1`.
- Add `certifi` (host + run).
- Add `setuptools >=18.0` to run (now a runtime dependency).
- Drop `cython` from run (build-only in 0.8.0); keep it in host.
- Relax `cykhash >=2.0` to `cykhash >=2` to match `build-system.requires`.

## Verification

- `sha256` matches the sdist published on PyPI.
- Host/run requirements mirror `install_requires` and `build-system.requires` in the 0.8.0 source distribution.
- Confirmed every dependency is available on conda-forge at the required versions (`protobuf 6.33.5`, `cykhash 2.0.1`, `certifi`, `python-rapidjson`).

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
