### PR TITLE
pyrosm v0.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.0" %}
+{% set version = "0.9.0" %}
 {% set name = "pyrosm" %}
 
 package:
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 0774b5e853be74e4e292eb0073f321ccd42658e622c317af2f31e164e4969fb7
+  sha256: 7c0716cbb9dd26c5055b1f1aa7c6c29da6a23f781d7e762b80c6758f32c1fa12
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<310]
 


### PR DESCRIPTION
Updates the feedstock to pyrosm 0.9.0 ([PyPI release](https://pypi.org/project/pyrosm/0.9.0/)).

## Changes

- Bump `version` to `0.9.0` and update `sha256` to match the PyPI sdist (`pyrosm-0.9.0.tar.gz`).
- Reset build number to `0` (version bump; previous build was `1`).
- No dependency changes: 0.9.0's `install_requires` and `build-system.requires` are identical to 0.8.0.

## Verification

- `sha256` matches the sdist published on PyPI (verified against a locally downloaded copy).
- Host/run requirements still mirror the 0.9.0 source distribution's `install_requires` (`python-rapidjson`, `setuptools >=18.0`, `geopandas >=0.12.0`, `shapely >=2.1`, `cykhash`, `protobuf >=6.33.5`, `certifi`) and `build-system.requires` (`setuptools`, `wheel`, `Cython`, `cykhash >=2`).

AI assistants: Claude Opus 4.8 (claude-opus-4-8, xhigh reasoning) via Claude Code 2.1.153.
