### PR TITLE
pyrosm v0.9.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.9.0" %}
+{% set version = "0.9.1" %}
 {% set name = "pyrosm" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7c0716cbb9dd26c5055b1f1aa7c6c29da6a23f781d7e762b80c6758f32c1fa12
+  sha256: 20b16f98bbbbea4427ce4587fdaaa8d179c10094bbfa3a62b0a58e28d5345d11
 
 build:
   number: 0


### PR DESCRIPTION
Updates the feedstock to pyrosm 0.9.1 ([PyPI release](https://pypi.org/project/pyrosm/0.9.1/)).

## Changes

- Bump `version` to `0.9.1` and update `sha256` to match the PyPI sdist (`pyrosm-0.9.1.tar.gz`).
- Build number stays `0` (version bump).
- No dependency changes: 0.9.1's `install_requires` and `build-system.requires` are identical to 0.9.0.

## Verification

- `sha256` matches the sdist published on PyPI (verified against a locally downloaded copy).
- Host/run requirements still mirror the 0.9.1 source distribution's `install_requires` (`python-rapidjson`, `setuptools >=18.0`, `geopandas >=0.12.0`, `shapely >=2.1`, `cykhash`, `protobuf >=6.33.5`, `certifi`) and `build-system.requires` (`setuptools`, `wheel`, `Cython`, `cykhash >=2`).

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.
