### PR TITLE
pyrosm v0.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.10.0" %}
+{% set version = "0.11.0" %}
 {% set name = "pyrosm" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7ce4e8673bc72c51c4b99d74c0609215a81e5c9e4a09dcbd2ee35e94fe7e2633
+  sha256: d81ebda14461c570cdb757b4ac9ec369f5a8959eba5eff6edd7760653aeb4600
 
 build:
   number: 0


### PR DESCRIPTION
Updates the feedstock to pyrosm 0.11.0 ([PyPI release](https://pypi.org/project/pyrosm/0.11.0/)).

## Changes

- Bump `version` to `0.11.0` and update `sha256` to match the PyPI sdist (`pyrosm-0.11.0.tar.gz`).
- Build number stays `0` (version bump).
- No dependency changes: 0.11.0's `install_requires` and `build-system.requires` are identical to the current recipe (0.10.0).

## Verification

- `sha256` matches the sdist published on PyPI (verified against a locally downloaded copy).
- Host/run requirements still mirror the 0.11.0 source distribution's `install_requires` (`python-rapidjson`, `setuptools >=18.0`, `geopandas >=0.12.0`, `shapely >=2.1`, `cykhash`, `protobuf >=6.33.5`, `certifi`) and `build-system.requires` (`setuptools`, `wheel`, `Cython`, `cykhash >=2`).
- Branched from the current feedstock `main` (0.10.0, already re-rendered with conda-smithy 2026.6.14), so no CI/config regeneration is bundled in this change.

AI assistants: Claude Opus 4.8 (claude-opus-4-8, max reasoning) via Claude Code 2.1.153.
